### PR TITLE
Add `chrono` dependency and timestamp handling to chat history

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -330,6 +330,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 name = "chauri"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "diesel",
  "dotenvy",
  "r2d2",
@@ -351,8 +352,10 @@ checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-targets 0.52.6",
 ]
 
@@ -596,6 +599,7 @@ version = "2.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "158fe8e2e68695bd615d7e4f3227c0727b151330d3e253b525086c348d055d5e"
 dependencies = [
+ "chrono",
  "diesel_derives",
  "libsqlite3-sys",
  "r2d2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -26,5 +26,6 @@ reqwest = { version = "0.12.9", features = ["json"] }
 dotenvy = "0.15.7"
 tokio = "1.41.0"
 uuid = { version = "1.11.0", features = ["v4"] }
-diesel = { version = "2.2.4", features = ["sqlite", "r2d2"] }
+diesel = { version = "2.2.4", features = ["sqlite", "r2d2", "chrono"] }
 r2d2 = "0.8.10"
+chrono = { version = "0.4.38", features = ["serde"] }


### PR DESCRIPTION
- Added `chrono` as a dependency in `Cargo.toml` with the `serde` feature enabled.
- Updated `Cargo.lock` to include `chrono` and its dependencies.
- Modified the `chat_history` table to include a `created_at` timestamp column with a default value of the current timestamp.
- Updated the `ChatHistory` and `NewChatHistory` structs to handle the `created_at` field using `chrono::NaiveDateTime`.
- Adjusted the `chat_gpt` function to order chat history by `created_at` and included the current timestamp when inserting new chat entries.
- Enhanced the `get_chat_history` function to return the `created_at` timestamp as a string.
- Refactored message construction in `chat_gpt` to maintain order and addressed message handling for API requests.