### PR TITLE
Refactor GitHub Actions workflows for release and build processes

### DIFF
--- a/.github/workflows/publish-to-manual-release.yml
+++ b/.github/workflows/publish-to-manual-release.yml
@@ -1,48 +1,15 @@
 name: "publish"
 
 on:
-  pull_request:
+  push:
     branches:
       - release
-    types: [opened, synchronize, reopened]
+
+# This is the example from the readme.
+# On each push to the `release` branch it will create or update a GitHub release, build your app, and upload the artifacts to the release.
 
 jobs:
-  create-release:
-    permissions:
-      contents: write
-    runs-on: ubuntu-latest
-    outputs:
-      release_id: ${{ steps.create-release.outputs.result }}
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: setup node
-        uses: actions/setup-node@v4
-        with:
-          node-version: lts/*
-
-      - name: get version
-        run: echo "PACKAGE_VERSION=$(node -p "require('./package.json').version")" >> $GITHUB_ENV
-
-      - name: create release
-        id: create-release
-        uses: actions/github-script@v6
-        with:
-          script: |
-            const { data } = await github.rest.repos.createRelease({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              tag_name: `app-v${process.env.PACKAGE_VERSION}`,
-              name: `Desktop App v${process.env.PACKAGE_VERSION}`,
-              body: 'Take a look at the assets to download and install this app.',
-              draft: true,
-              prerelease: false
-            })
-            return data.id
-
-  build-tauri:
-    needs: create-release
+  publish-tauri:
     permissions:
       contents: write
     strategy:
@@ -88,27 +55,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          releaseId: ${{ needs.create-release.outputs.release_id }}
+          tagName: app-v__VERSION__ # the action automatically replaces \_\_VERSION\_\_ with the app version.
+          releaseName: "App v__VERSION__"
+          releaseBody: "See the assets to download this version and install."
+          releaseDraft: true
+          prerelease: false
           args: ${{ matrix.args }}
-
-  publish-release:
-    permissions:
-      contents: write
-    runs-on: ubuntu-latest
-    needs: [create-release, build-tauri]
-
-    steps:
-      - name: publish release
-        id: publish-release
-        uses: actions/github-script@v6
-        env:
-          release_id: ${{ needs.create-release.outputs.release_id }}
-        with:
-          script: |
-            github.rest.repos.updateRelease({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              release_id: process.env.release_id,
-              draft: false,
-              prerelease: false
-            })

--- a/.github/workflows/test-build-only.yml
+++ b/.github/workflows/test-build-only.yml
@@ -1,6 +1,9 @@
 name: "build"
 
-on: [push]
+on:
+  push:
+    branches-ignore:
+      - release
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
     cancel-in-progress: true


### PR DESCRIPTION
- Updated `publish-to-manual-release.yml` to trigger on push to the `release` branch instead of pull request events.
- Simplified the release creation process by removing the `create-release` and `publish-release` jobs, consolidating them into the `publish-tauri` job.
- Adjusted the `publish-tauri` job to automatically handle versioning and release details.
- Excluded the `release` branch from triggering the `test-build-only.yml` workflow by adding `branches-ignore`.
- Improved the overall workflow efficiency and clarity by removing redundant steps and utilizing automatic version replacement in tags and release names.