### PR TITLE
Remove dotenvy dependency from Cargo.toml and Cargo.lock

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -536,7 +536,6 @@ dependencies = [
  "chrono",
  "diesel",
  "dirs",
- "dotenvy",
  "r2d2",
  "reqwest",
  "rusqlite",
@@ -702,12 +701,6 @@ dependencies = [
  "quote",
  "syn 2.0.85",
 ]
-
-[[package]]
-name = "dotenvy"
-version = "0.15.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "dpi"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -23,7 +23,6 @@ tauri-plugin-shell = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 reqwest = { version = "0.12.9", features = ["json"] }
-dotenvy = "0.15.7"
 tokio = "1.41.0"
 uuid = { version = "1.11.0", features = ["v4"] }
 diesel = { version = "2.2.4", features = ["sqlite", "r2d2", "chrono"] }


### PR DESCRIPTION
The dotenvy dependency was removed from both the Cargo.toml and Cargo.lock files as it is no longer needed in the project.