### PR TITLE
fix: Update workflow to trigger on all release branches

### DIFF
--- a/.github/workflows/publish-to-auto-release.yml
+++ b/.github/workflows/publish-to-auto-release.yml
@@ -3,7 +3,7 @@ name: "publish"
 on:
   push:
     branches:
-      - release
+      - release/**
 
 # This is the example from the readme.
 # On each push to the `release` branch it will create or update a GitHub release, build your app, and upload the artifacts to the release.


### PR DESCRIPTION
- Changed the trigger condition from the 'release' branch to all branches under the 'release/**' pattern for the publish workflow.