### PR TITLE
feat: Add workflow to cleanup caches by a branch

### DIFF
--- a/.github/workflows/cleanup-chaches-by-a-branch.yml
+++ b/.github/workflows/cleanup-chaches-by-a-branch.yml
@@ -1,0 +1,27 @@
+name: cleanup caches by a branch
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cleanup
+        run: |
+          echo "Fetching list of cache key"
+          cacheKeysForPR=$(gh cache list --ref $BRANCH --limit 100 --json id --jq '.[].id')
+
+          ## Setting this to not fail the workflow while deleting cache keys.
+          set +e
+          echo "Deleting caches..."
+          for cacheKey in $cacheKeysForPR
+          do
+              gh cache delete $cacheKey
+          done
+          echo "Done"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          BRANCH: refs/pull/${{ github.event.pull_request.number }}/merge


### PR DESCRIPTION
- Create a GitHub Actions workflow that triggers on closed pull requests.
- The workflow lists and deletes cache keys associated with the closed pull request.
- Utilizes GitHub CLI commands to manage caches effectively.