### PR TITLE
Add conditional check for branch cleanup

### DIFF
--- a/.github/workflows/cleanup-chaches-by-a-branch.yml
+++ b/.github/workflows/cleanup-chaches-by-a-branch.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   cleanup:
+    if: ${{ !(github.event.pull_request.base.ref == 'master' && github.event.pull_request.head.ref == 'develop') }}
     runs-on: ubuntu-latest
     steps:
       - name: Cleanup


### PR DESCRIPTION
- Introduced a conditional statement to the `cleanup` job in the GitHub Actions workflow.
- The job will not run if the base branch is 'master' and the head branch is 'develop'.
- Ensures that cache cleanup is skipped for pull requests from 'develop' to 'master'.
- This change helps optimize workflow runs by avoiding unnecessary cleanup operations.