### PR TITLE
Update GitHub Actions workflow branch from 'main' to 'master'

### DIFF
--- a/.github/workflows/publish-to-auto-release.yml
+++ b/.github/workflows/publish-to-auto-release.yml
@@ -3,7 +3,7 @@ name: "publish"
 on:
   push:
     branches:
-      - main
+      - master
 
 jobs:
   test-tauri:


### PR DESCRIPTION
The workflow configuration for publishing in '.github/workflows/publish-to-auto-release.yml' has been updated to trigger on pushes to the 'master' branch instead of the 'main' branch. This change ensures that the automation is aligned with the current default branch naming in the repository.