### PR TITLE
Remove unused 'dirs' dependency in get_database_path.rs

### DIFF
--- a/src-tauri/src/get_database_path.rs
+++ b/src-tauri/src/get_database_path.rs
@@ -1,4 +1,3 @@
-use dirs;
 use std::fs;
 use std::io;
 


### PR DESCRIPTION
This commit eliminates the import of the 'dirs' crate in the get_database_path.rs file, as it was not being utilized. This cleanup helps to improve code readability and reduce unnecessary dependencies.