### PR TITLE
Add dompurify

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@tauri-apps/plugin-shell": "^2",
         "bootstrap": "^5.3.3",
         "dayjs": "^1.11.13",
+        "dompurify": "^3.2.4",
         "marked": "^15.0.7",
         "uuid": "^11.1.0",
         "vue": "^3.5.13",
@@ -1137,6 +1138,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/yauzl": {
       "version": "2.10.3",
       "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
@@ -1785,6 +1793,15 @@
       "dev": true,
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/dompurify": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.4.tgz",
+      "integrity": "sha512-ysFSFEDVduQpyhzAob/kkuJjf5zWkZD8/A9ywSp1byueyuCfHamrCBa14/Oc2iiB0e51B+NpxSl5gmzn+Ms/mg==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/electron": {
       "version": "32.3.1",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@tauri-apps/plugin-shell": "^2",
     "bootstrap": "^5.3.3",
     "dayjs": "^1.11.13",
+    "dompurify": "^3.2.4",
     "marked": "^15.0.7",
     "uuid": "^11.1.0",
     "vue": "^3.5.13",

--- a/src/renderMarkdown.ts
+++ b/src/renderMarkdown.ts
@@ -1,8 +1,8 @@
 import { Marked } from "marked";
-import { Markdown } from "./types";
+import { Markdown, Html } from "./types";
 import DOMPurify from "dompurify";
 
-export function renderMarkdown(markdownText: Markdown): string {
+export function renderMarkdown(markdownText: Markdown): Html {
   const marked = new Marked();
 
   marked.use({
@@ -10,7 +10,7 @@ export function renderMarkdown(markdownText: Markdown): string {
   });
 
   const html = marked.parse(markdownText) as string;
-  const sanitized_html = DOMPurify.sanitize(html);
+  const sanitized_html = DOMPurify.sanitize(html) as Html;
 
   return sanitized_html;
 }

--- a/src/renderMarkdown.ts
+++ b/src/renderMarkdown.ts
@@ -1,7 +1,16 @@
-import { marked } from "marked";
-import { Markdown, Html } from "./types";
+import { Marked } from "marked";
+import { Markdown } from "./types";
+import DOMPurify from "dompurify";
 
-export function renderMarkdown(markdownText: Markdown): Html {
-  const html = marked(markdownText) as Html;
-  return html;
+export function renderMarkdown(markdownText: Markdown): string {
+  const marked = new Marked();
+
+  marked.use({
+    async: false,
+  });
+
+  const html = marked.parse(markdownText) as string;
+  const sanitized_html = DOMPurify.sanitize(html);
+
+  return sanitized_html;
 }


### PR DESCRIPTION
- Install `dompurify` and add the optional `@types/trusted-types` dependency
- Update `renderMarkdown.ts` to sanitize parsed HTML from Marked using DOMPurify
- Ensure Marked is properly configured for synchronous parsing