### PR TITLE
docs: update README and refine security permissions & Tauri config

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ Cuuri is a GUI client for ChatGPT built with Tauri, Vue, and TypeScript.
 
 ![Screenshot](./public/screenshot.png)
 
+[!WARNING]
+Cuuri is in its early stages of development, and many features are missing. In particular, security features are incomplete and are currently being worked on. Please use at your own risk.
+
 ### Features
 
 - Privacy
@@ -29,20 +32,20 @@ Cuuri is a GUI client for ChatGPT built with Tauri, Vue, and TypeScript.
 1. Clone this repository.
 
     ```bash
-    $ https://github.com/takanotume24/Cuuri.git
-    $ cd Cuuri
+    https://github.com/takanotume24/Cuuri.git
+    cd Cuuri
     ```
 
 1. Install npm dependencies.
 
     ```bash
-    $ npm install
+    npm install
     ```
   
 1. Build the project.
 
     ```bash
-    $ npm run tauri build
+    npm run tauri build
     ```
 
 1. Run the built binary to install.
@@ -57,4 +60,3 @@ All Cuuri data is saved under `$HOME/.cuuri`. Typically, the following files are
 - `$HOME/.cuuri/config.toml`
   - `default_model`: You can set the model that is selected at startup. Make sure the model name matches the one shown in the list.
   - `openai_api_key`: Set your OpenAI API key here.
-

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -5,6 +5,8 @@
   "windows": ["main"],
   "permissions": [
     "core:default",
-    "shell:allow-open"
+    "allow-rw-config-file",
+    "allow-rw-db-file",
+    "allow-get-available-models"
   ]
 }

--- a/src-tauri/permissions/allow-get-available-models.toml
+++ b/src-tauri/permissions/allow-get-available-models.toml
@@ -1,0 +1,11 @@
+[[permission]]
+identifier = "allow-get-available-models"
+description = ""
+
+[permission.commands]
+allow = [
+  "get_available_models",
+]
+
+[[scope.allow]]
+

--- a/src-tauri/permissions/allow-rw-config-file.toml
+++ b/src-tauri/permissions/allow-rw-config-file.toml
@@ -1,0 +1,13 @@
+[[permission]]
+identifier = "allow-rw-config-file"
+description = ""
+
+[permission.commands]
+allow = [
+  "set_openai_api_key",
+  "get_openai_api_key",
+  "get_default_model",
+]
+
+[[scope.allow]]
+path = "$HOME/**"

--- a/src-tauri/permissions/allow-rw-config-file.toml
+++ b/src-tauri/permissions/allow-rw-config-file.toml
@@ -10,4 +10,4 @@ allow = [
 ]
 
 [[scope.allow]]
-path = "$HOME/**"
+path = "$HOME/.cuuri/config.toml"

--- a/src-tauri/permissions/allow-rw-db-file.toml
+++ b/src-tauri/permissions/allow-rw-db-file.toml
@@ -1,0 +1,14 @@
+[[permission]]
+identifier = "allow-rw-db-file"
+description = ""
+
+commands.allow = [
+  "get_chatgpt_response",
+  "get_chat_history",
+  "get_chat_history_by_session",
+  "get_session_id_list",
+  "stream_chatgpt_response"
+]
+
+[[scope.allow]]
+path = "$HOME/.cuuri/chat.db"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -25,10 +25,10 @@
       "csp": {
         "default-src": "'self'",
         "script-src": "'self'",
-        "style-src": "'self' 'unsafe-inline'",
+        "style-src": "'self'",
         "object-src": "'none'",
         "connect-src": "'self'",
-        "img-src": "'self' data:",
+        "img-src": "'self'",
         "frame-src": "'none'"
       }
     }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -14,11 +14,23 @@
       {
         "title": "Cuuri",
         "width": 1100,
-        "height": 600
+        "height": 600,
+        "resizable": true,
+        "fullscreen": false,
+        "center": true,
+        "visible": true
       }
     ],
     "security": {
-      "csp": null
+      "csp": {
+        "default-src": "'self'",
+        "script-src": "'self'",
+        "style-src": "'self' 'unsafe-inline'",
+        "object-src": "'none'",
+        "connect-src": "'self'",
+        "img-src": "'self' data:",
+        "frame-src": "'none'"
+      }
     }
   },
   "bundle": {


### PR DESCRIPTION
docs: update README and refine security permissions & Tauri config

- Add a warning to README noting early-stage development and incomplete security features.
- Clean up installation command examples in README by removing extraneous '$' symbols.
- Replace generic "shell:allow-open" with specific granular permissions:
  - allow-rw-config-file: restricts access to "$HOME/.cuuri/config.toml" for API key and default model operations.
  - allow-rw-db-file: grants controlled access to "$HOME/.cuuri/chat.db" for chat operations.
  - allow-get-available-models: enables fetching available models.
- Update tauri.conf.json:
  - Expand window configuration with "resizable", "fullscreen", "center", and "visible" properties.
  - Enforce explicit Content Security Policy directives, removing unsafe settings.

These changes improve documentation clarity and enhance overall security.