### PR TITLE
feat: add permission for generating session IDs

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -7,6 +7,7 @@
     "core:default",
     "allow-rw-config-file",
     "allow-rw-db-file",
-    "allow-get-available-models"
+    "allow-get-available-models",
+    "allow-generate-session-id"
   ]
 }

--- a/src-tauri/permissions/allow-generate-session-id.toml
+++ b/src-tauri/permissions/allow-generate-session-id.toml
@@ -1,0 +1,11 @@
+[[permission]]
+identifier = "allow-generate-session-id"
+description = ""
+
+[permission.commands]
+allow = [
+  "generate_session_id",
+]
+
+[[scope.allow]]
+


### PR DESCRIPTION
- Added a new "allow-generate-session-id" permission in default.json.
- Created a corresponding "allow-generate-session-id.toml" file to manage the permission for the "generate_session_id" command.