### PR TITLE
Potential fix for code scanning alert no. 34: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-build-only.yml
+++ b/.github/workflows/test-build-only.yml
@@ -1,5 +1,8 @@
 name: "build"
 
+permissions:
+  contents: read
+
 on:
   push:
     branches-ignore:


### PR DESCRIPTION
Potential fix for [https://github.com/takanotume24/Cuuri/security/code-scanning/34](https://github.com/takanotume24/Cuuri/security/code-scanning/34)

To fix the issue, we will add a `permissions` block at the root level of the workflow file to limit access to the `GITHUB_TOKEN`. Since the workflow appears to primarily involve building and testing the application, the `contents: read` permission is sufficient for accessing the repository code. This ensures that the `GITHUB_TOKEN` cannot be used for unintended operations, such as writing to the repository or accessing sensitive resources.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
