### PR TITLE
Potential fix for code scanning alert no. 33: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cleanup-chaches-by-a-branch.yml
+++ b/.github/workflows/cleanup-chaches-by-a-branch.yml
@@ -1,3 +1,6 @@
+permissions:
+  contents: read
+  actions: read
 name: cleanup caches by a branch
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/takanotume24/Cuuri/security/code-scanning/33](https://github.com/takanotume24/Cuuri/security/code-scanning/33)

To address the issue, we will add an explicit `permissions` block at the workflow root to ensure least privilege. The `permissions` block will grant:
- `contents: read` access, which is often necessary for general workflow operations.
- `actions: read` access to interact with caches if required (GitHub caches are part of Actions).

This will restrict the scope of the `GITHUB_TOKEN` to only the necessary permissions for listing and deleting caches.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
